### PR TITLE
Added freedom to choose k terms based on octal notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cm_desc = CoulombMatrix(n_atoms_max=n_atoms_max)
 sm_desc = SineMatrix(n_atoms_max=n_atoms_max)
 mbtr_desc = MBTR(
     atomic_numbers=atomic_numbers,
-    k=2,
+    k=3,
     periodic=True,
     weighting="exponential")
 

--- a/examples/aseatoms.py
+++ b/examples/aseatoms.py
@@ -27,4 +27,4 @@ atomic_numbers = stats["atomic_numbers"]
 # Create descriptors for this system directly from the ASE atoms
 cm = CoulombMatrix(n_atoms_max).create(atoms)
 sm = SineMatrix(n_atoms_max).create(atoms)
-mbtr = MBTR(atomic_numbers, k=3, periodic=True, weighting="exponential").create(atoms)
+mbtr = MBTR(atomic_numbers, k=7, periodic=True, weighting="exponential").create(atoms)

--- a/examples/mbtr.py
+++ b/examples/mbtr.py
@@ -28,7 +28,7 @@ NaCl_conv = System(
 decay_factor = 0.5
 mbtr = MBTR(
     atomic_numbers=[11, 17],
-    k=3,
+    k=7,
     periodic=True,
     grid={
         "k1": {

--- a/examples/readme.py
+++ b/examples/readme.py
@@ -27,7 +27,7 @@ cm_desc = CoulombMatrix(n_atoms_max=n_atoms_max)
 sm_desc = SineMatrix(n_atoms_max=n_atoms_max)
 mbtr_desc = MBTR(
     atomic_numbers=atomic_numbers,
-    k=2,
+    k=3,
     periodic=True,
     weighting="exponential")
 


### PR DESCRIPTION
Also updated README.md with corresponding k value in example

With this, different set of k terms can be considered in MBTR.
Works like chmod, as explained in docs of class `MBTR` in `./describe/descriptors/mbtr.py`.
```
k (int): The interaction terms to consider. It uses octal notation,
    like chmod. It is the sum of its component bits in the binary 
    numeral system. As a result, specific bits add to the sum as it 
    is represented by a numeral:
        The k1 bit adds 4 to its total (in binary 100),
        The k2 bit adds 2 to its total (in binary 010), and
        The k3 bit adds 1 to its total (in binary 001).
    These values never produce ambiguous combinations; each sum, 1-7, 
    represents a specific set of k terms.
    The size of the final output and the time taken in creating this 
    descriptor is exponentially dependent on this value.
```
|#|K terms|
|:---:|:--:|
|7|K1, K2 and K3|
|6|K1 and K2|
|5|K1 and K3|
|4|K1|
|3|K2 and K3|
|2|K2|
|1|K3|